### PR TITLE
Add node.js setup and npm publish steps to gh workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
   "features": {
     "ghcr.io/devcontainers/features/git" : {},
     "ghcr.io/devcontainers/features/go:1": {"version": "1.25.1"},
-    "ghcr.io/devcontainers/features/java:1": {"version": "21.0.7", "installGradle": true},
+    "ghcr.io/devcontainers/features/java:1": {"version": "25", "installGradle": true},
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/mrsimonemms/devcontainers/buf:1": {}
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,73 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
 
+      - name: "🔧 Setup Node"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: "Prepare npm auth"
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "NPM_TOKEN secret is not set. Skipping npm publish."
+            exit 1
+          fi
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: "Extract version from tag"
+        id: version
+        run: |
+          RAW_TAG="${GITHUB_REF##*/}"
+          VERSION="${RAW_TAG#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: "Prepare npm package.json for sdk/js"
+        working-directory: sdk/js
+        run: |
+          cat > package.json <<EOF
+          {
+            "name": "@o7studios/octopus-sdk",
+            "version": "${{ steps.version.outputs.version }}",
+            "description": "Octopus JavaScript SDK",
+            "type": "module",
+            "main": "./gen/index.js",
+            "types": "./gen/index.d.ts",
+            "files": [
+              "gen"
+            ],
+            "scripts": {
+              "build": "echo 'No build step'",
+              "prepublishOnly": "npm run build"
+            },
+            "author": "Julian Siebert <julian.siebert@o7.studio>",
+            "license": "GPL-3.0",
+            "repository": {
+              "type": "git",
+              "url": "https://github.com/o7studios/octopus-sdk.git"
+            },
+            "homepage": "https://o7.studio",
+            "bugs": {
+              "url": "https://github.com/o7studios/octopus-sdk/issues"
+            },
+            "publishConfig": {
+              "access": "public"
+            }
+          }
+          EOF
+
+      - name: "Check package contents"
+        working-directory: sdk/js
+        run: |
+          npm pack --dry-run
+
+      - name: "🚀 Publish to npm"
+        working-directory: sdk/js
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish --access public
+
       - name: ⚡ Setup Gradle with Cache
         uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: "🔧 Setup Node"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: "Prepare npm auth"
@@ -117,44 +117,12 @@ jobs:
           VERSION="${RAW_TAG#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: "Prepare npm package.json for sdk/js"
+      - run: npm version $VERSION
         working-directory: sdk/js
-        run: |
-          cat > package.json <<EOF
-          {
-            "name": "@o7studios/octopus-sdk",
-            "version": "${{ steps.version.outputs.version }}",
-            "description": "Octopus JavaScript SDK",
-            "type": "module",
-            "main": "./gen/index.js",
-            "types": "./gen/index.d.ts",
-            "files": [
-              "gen"
-            ],
-            "scripts": {
-              "build": "echo 'No build step'",
-              "prepublishOnly": "npm run build"
-            },
-            "author": "Julian Siebert <julian.siebert@o7.studio>",
-            "license": "GPL-3.0",
-            "repository": {
-              "type": "git",
-              "url": "https://github.com/o7studios/octopus-sdk.git"
-            },
-            "homepage": "https://o7.studio",
-            "bugs": {
-              "url": "https://github.com/o7studios/octopus-sdk/issues"
-            },
-            "publishConfig": {
-              "access": "public"
-            }
-          }
-          EOF
-
-      - name: "Check package contents"
+      - run: npm ci
         working-directory: sdk/js
-        run: |
-          npm pack --dry-run
+      - run: npm publish --dry-run
+        working-directory: sdk/js
 
       - name: "🚀 Publish to npm"
         working-directory: sdk/js

--- a/sdk/js/.gitignore
+++ b/sdk/js/.gitignore
@@ -1,1 +1,2 @@
 gen
+node_modules

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "@o7studios/octopus-sdk",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@o7studios/octopus-sdk",
+      "version": "0.0.1",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.10.0",
+        "google-protobuf": "^4.0.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.0.tgz",
+      "integrity": "sha512-fdRs9PSrBF7QUntpZpq6BTw58fhgGJojgg39m9oFOJGZT+nip9b0so5cYY1oWl5pvemDLr0cPPsH46vwThEbpQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/google-protobuf": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-4.0.0.tgz",
+      "integrity": "sha512-b8wmenhUMf2WNL+xIJ/slvD/hEE6V3nRnG86O2bzkBrMweM9gnqZE1dfXlDjibY3aXJXDNbAHepevYyQ7qWKsQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    }
+  }
+}

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@o7studios/octopus-sdk",
+  "version": "0.0.1",
+  "description": "SDK for o7studios product Octopus",
+  "type": "module",
+  "main": "./gen/api/v1/api_grpc_pb.js",
+  "types": "./gen/api/v1/api_pb.d.ts",
+  "files": [
+    "gen"
+  ],
+  "scripts": {
+    "build": "echo 'No build step'",
+    "prepublishOnly": "npm run build"
+  },
+  "author": "Julian Siebert <julian.siebert@o7.studio>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/o7studios/octopus-sdk.git"
+  },
+  "homepage": "https://o7.studio",
+  "bugs": {
+    "url": "https://github.com/o7studios/octopus-sdk/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^2.10.0",
+    "google-protobuf": "^4.0.0"
+  }
+}


### PR DESCRIPTION
I'm not entirely sure if this works out especially because I'm not sure if everything is correctly generated and exported regarding the js files

this probably should not be merged before this is clarified

also this addition requires:
- @o7studios organization on npm if we want to publish it under that name
- npm auth token from whoever from us wants to create the organization ig
- this token should also be added as a secret (NPM_TOKEN)

Maybe the package.json can also be seperated into a different file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JavaScript SDK package metadata to enable publishing to npm.

* **Chores**
  * Automated npm publishing added to the release workflow (Node setup, tag-based versioning, validation dry-run, then public publish); existing Gradle/Maven publishing unchanged.
  * Development container Java version updated.
  * JS .gitignore updated to exclude node_modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->